### PR TITLE
Add truthiness check to MessageGenerator

### DIFF
--- a/src/protocolbuffers/generator/php/MessageGenerator.php
+++ b/src/protocolbuffers/generator/php/MessageGenerator.php
@@ -543,7 +543,7 @@ class MessageGenerator
             if ($dict->getLeadingComments()) {
                 $lines = preg_split("/\r?\n/", trim($dict->getLeadingComments()));
                 foreach ($lines as $line) {
-                    if ($line[0] == " ") {
+                    if ($line && $line[0] == " ") {
                         $line = substr($line, 1);
                     }
                     $printer->put(" * `comment`\n", "comment", $line);


### PR DESCRIPTION
This bugfix adds a truthiness check in the comment section of MessageGenerator.

Given the following message excerpt from rethinkdb ql2.proto:

``` protobuf
// A [Term] is either a piece of data (see **Datum** above), or an operator and
// its operands.  If you have a [Datum], it's stored in the member [datum].  If
// you have an operator, its positional arguments are stored in [args] and its
// optional arguments are stored in [optargs].
//
// A note about type signatures:
```

The MessageGenerator would build the following array

``` php
array (
  0 => 'A [Term] is either a piece of data (see **Datum** above), or an operator and',
  1 => ' its operands.  If you have a [Datum], it\'s stored in the member [datum].  If',
  2 => ' you have an operator, its positional arguments are stored in [args] and its',
  3 => ' optional arguments are stored in [optargs].',
  4 => '',
  5 => ' A note about type signatures:',
```

When attempting to check and remove a leading space it would throw the following notice for empty strings:

```
  PHP Notice:  Uninitialized string offset: 0 in /home/vagrant/protoc-gen-php/src/protocolbuffers/generator/php/MessageGenerator.php on line 546
  PHP Stack trace:
  PHP   1. {main}() /home/vagrant/protoc-gen-php/bin/protoc-gen-php:0
  PHP   2. Symfony\Component\Console\Application->run() /home/vagrant/protoc-gen-php/bin/protoc-gen-php:31
  PHP   3. Symfony\Component\Console\Application->doRun() /home/vagrant/protoc-gen-php/vendor/symfony/console/Symfony/Component/Console/Application.php:126
  PHP   4. Symfony\Component\Console\Application->doRunCommand() /home/vagrant/protoc-gen-php/vendor/symfony/console/Symfony/Component/Console/Application.php:195
  PHP   5. Symfony\Component\Console\Command\Command->run() /home/vagrant/protoc-gen-php/vendor/symfony/console/Symfony/Component/Console/Application.php:874
  PHP   6. protocolbuffers\console\command\GenerateCommand->execute() /home/vagrant/protoc-gen-php/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:253
  PHP   7. protocolbuffers\Compiler->compile() /home/vagrant/protoc-gen-php/src/protocolbuffers/console/command/GenerateCommand.php:29
  PHP   8. protocolbuffers\generator\php\Generator->generate() /home/vagrant/protoc-gen-php/src/protocolbuffers/Compiler.php:204
  PHP   9. protocolbuffers\generator\php\FileGenerator->generateSiblings() /home/vagrant/protoc-gen-php/src/protocolbuffers/generator/php/Generator.php:68
  PHP  10. protocolbuffers\generator\php\MessageGenerator->generate() /home/vagrant/protoc-gen-php/src/protocolbuffers/generator/php/FileGenerator.php:168
```
